### PR TITLE
Add JUnit to testCompile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ processResources {
 
 dependencies {
     deobfCompile 'com.elytradev:probedataproviderapi:MC1.11.2_ver1.1.1'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
 jar {


### PR DESCRIPTION
Forge-gradle runs JUnit tests in the build during the testCompile phase even if JUnit isn't on the buildpath. The BlockState validator is a unit test, so adding this fixes errors during a from-scratch reobf build.